### PR TITLE
日本語デスクトップで起動できるようにする

### DIFF
--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -3,9 +3,19 @@ search --set=root --file /%DISTRO_UNAME%
 insmod all_video
 
 set default="0"
-set timeout=30
+set timeout=-1
 
-menuentry "Install %DISTRO_NAME%" {
+menuentry "%DISTRO_NAME% (Japanese - JP keyboard)" {
+   linux /live/vmlinuz boot=live nopersistent toram quiet splash --- locales=ja_JP.UTF-8 keyooard-layouts=jp
+   initrd /live/initrd
+}
+
+menuentry "%DISTRO_NAME% (Japanese - US keyboard)" {
+   linux /live/vmlinuz boot=live nopersistent toram quiet splash --- locales=ja_JP.UTF-8
+   initrd /live/initrd
+}
+
+menuentry "%DISTRO_NAME% (English)" {
    linux /live/vmlinuz boot=live nopersistent toram quiet splash ---
    initrd /live/initrd
 }


### PR DESCRIPTION
Kamukiti の公開を知り、触れさせていただきましたが、
日本発でカスタマイズに日本向けなのに、
英語でライブ起動していたので、
日本語でライブ起動するよう PR を入れました。
キーボードは日本語キーボード以外に
英語キーボードで使用する人がいるので（Mac など）
２種類にしています。
海外からの反応もあるようなので、
従来のオプションも残しています。
合わせてライブ起動するのに「Install」と表記していたので、
ここも修正しました。

ライブ起動で日本語表示、Fcitx 5 も Mozc で入力できるので、
インストールしなくても USB メモリに入れて
ライブ起動で使ってもらえるようになるのが期待できます。

よろしくお願いします。